### PR TITLE
allow to require/import the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,11 @@
   "module": "./esm/index.js",
   "type": "module",
   "exports": {
-    "import": "./esm/index.js",
-    "default": "./cjs/index.js"
+    ".": {
+      "import": "./esm/index.js",
+      "default": "./cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "unpkg": "min.js",
   "repository": {


### PR DESCRIPTION
Some build tools (for example rollup-plugin-svelte) require the package.json to resolve some fields. Without "./package.json" in the exports field this fails in node.js versions which only allow to import/require files specified in the exports field.